### PR TITLE
if you click a note then select unselectall of the other notes

### DIFF
--- a/src/app/(PianoRoll)/NoteLabel.tsx
+++ b/src/app/(PianoRoll)/NoteLabel.tsx
@@ -2,7 +2,12 @@ export default function NoteLabel({ noteName }: { noteName: string }) {
     return (
         <div
             className="absolute left-0 top-0 w-12 h-full flex items-center justify-center text-xs text-zinc-400 border-r border-zinc-700 bg-zinc-900"
-            style={{ position: "sticky", left: 0, zIndex: 1 }}
+            style={{
+                position: "sticky",
+                left: 0,
+                zIndex: 1,
+                userSelect: "none",
+            }}
         >
             {noteName}
         </div>

--- a/src/app/(PianoRoll)/PianoRoll.tsx
+++ b/src/app/(PianoRoll)/PianoRoll.tsx
@@ -85,6 +85,8 @@ export function PianoRoll({
         // If we are in write mode, then we should delete the note
         if (mode === "write") {
             removeNotes([notes[index]]);
+        } else {
+            setSelectedNotes([notes[index]]);
         }
     };
 


### PR DESCRIPTION
Unselect all other notes if you click on one while others are selected.

Fix the highlighting of labels when you drag-to-select