### PR TITLE
Fix Dragging after Resize

### DIFF
--- a/src/app/(PianoRoll)/DragSelectProvider.tsx
+++ b/src/app/(PianoRoll)/DragSelectProvider.tsx
@@ -59,10 +59,9 @@ function DragSelectProvider({
 
     useSubscribe({
         event: "DS:end",
-        callback: ({ items, event, isDragging }) => {
+        callback: ({ items, isDragging }) => {
             if (isDragging) {
                 // we've just dragged a selection
-                ds?.clearSelection();
                 handleDragEnd(items);
             } else {
                 // we've made a selection

--- a/src/app/(PianoRoll)/Note.tsx
+++ b/src/app/(PianoRoll)/Note.tsx
@@ -88,8 +88,9 @@ export default function Note({
                 handleResize(size.width - originalWidth);
             }}
             onResizeStop={(e: any, { size }: any) => {
-                // Prevent the drag select from being triggered
                 e.preventDefault();
+                // Prevent the drag select from being triggered
+                ds?.break();
                 commitResize();
             }}
             handle={

--- a/src/app/(PianoRoll)/PianoRoll.tsx
+++ b/src/app/(PianoRoll)/PianoRoll.tsx
@@ -35,6 +35,7 @@ export function PianoRoll({
     const { cellHeight, cellWidth, totalColumns, totalWidth } =
         getGridDimensions(notes, width, height);
 
+    // Combine into one function to make it simpler to pass through
     function updateNotes(
         oldNotes: ExtendedNoteJSON[],
         newNotes: ExtendedNoteJSON[]


### PR DESCRIPTION
If you resize a group a selected notes, then try to drag them, it would only drag the clicked note and not the whole group. 